### PR TITLE
Add Option to configure a different log files directory to add a bit more flexibility

### DIFF
--- a/Sources/NGLoggerKit/Implementation/Configuration/FileConfiguration.swift
+++ b/Sources/NGLoggerKit/Implementation/Configuration/FileConfiguration.swift
@@ -44,10 +44,27 @@ public struct FileConfiguration: LoggerConfigurationProtocol {
 		guard let cacheDirectory = cacheDirectoryUrl else {
 			return nil
 		}
-		self.file = cacheDirectory.appendingPathComponent("\(fileName).log")
-		self.formatter = formatter
-		self.shouldShowLogDetails = shouldShowLogDetails
-		self.filter = filter
-		self.autorotateConfiguration = autorotateConfiguration
-	}
+
+        self.init(
+            fileName: fileName,
+            logDirectory: cacheDirectory,
+            formatter: formatter,
+            filter: filter,
+            shouldShowLogDetails: shouldShowLogDetails,
+            autorotateConfiguration: autorotateConfiguration
+        )
+    }
+
+    public init(fileName: String,
+                logDirectory: URL,
+                formatter: LoggerFormatterProtocol,
+                filter: FilterProtocol,
+                shouldShowLogDetails: Bool,
+                autorotateConfiguration: AutoRotateConfiguration?) {
+        self.file = logDirectory.appendingPathComponent("\(fileName).log")
+        self.formatter = formatter
+        self.shouldShowLogDetails = shouldShowLogDetails
+        self.filter = filter
+        self.autorotateConfiguration = autorotateConfiguration
+    }
 }


### PR DESCRIPTION
This pull request includes a significant change to the `FileConfiguration` struct in the `Sources/NGLoggerKit/Implementation/Configuration/FileConfiguration.swift` file. The most important change is the addition of a new initializer to improve the configuration setup.

Initialization improvements:

* Added a new initializer to the `FileConfiguration` struct to allow more flexible configuration with parameters for `fileName`, `logDirectory`, `formatter`, `filter`, `shouldShowLogDetails`, and `autorotateConfiguration`. This change also refactors the existing initialization logic to use the new initializer.